### PR TITLE
Add 'git clone git://github.com/etgryphon/sproutcore-uds.git scuds' to README

### DIFF
--- a/README
+++ b/README
@@ -15,6 +15,7 @@ git checkout touch
 cd frameworks
 
 git clone git://github.com/etgryphon/sproutcore-ui.git scui
+git clone git://github.com/etgryphon/sproutcore-uds.git scuds
 
 git clone git://github.com/sproutit/sproutcore.git sproutcore
 cd sproutcore


### PR DESCRIPTION
Updated README -- the scuds framework is also needed to make a running instance.

PS: nice warning in the console:

```
To quit sc-server, press Control-C
>> Thin web server (v1.2.7 codename No Hup)
>> Maximum connections set to 1024
>> Listening on 0.0.0.0:4400, CTRL+C to stop
WARN ~ Could not find target scuds that is required by /core-tasks 
```
